### PR TITLE
Update github project name in setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author='matiboy',
     author_email='mathieu@redapesolutions.com',
-    url='https://github.com/matiboy/django-safari-notifications',
+    url='https://github.com/matiboy/django_safari_notifications',
     packages=[
         'django_safari_notifications',
     ],


### PR DESCRIPTION
s/django-safari-notifications/django_safari_notifications/

A trivial change but without it the link from PyPI to the source repository is currently broken, so I thought I'd bring it to your attention anyway.

Thanks for sharing your code!